### PR TITLE
Fixed incorrect link in index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,7 @@
 </head>
 <body>
 	
-	<a href="https://github.com/SamBumgardner/Floe"><img style="position: absolute; top: 0; left: 0; border: 0;"
+	<a href="https://github.com/SamBumgardner/Shield-Game"><img style="position: absolute; top: 0; left: 0; border: 0;"
 			src="https://camo.githubusercontent.com/121cd7cbdc3e4855075ea8b558508b91ac463ac2/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f677265656e5f3030373230302e706e67"
 			alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_green_007200.png"></a>
 


### PR DESCRIPTION
The "fork me on Github" link used to go to Floe's repository, but now
it correctly goes to the Shield-Game repository.

It was a silly mistake that I'd rather have fixed sooner rather than later.